### PR TITLE
Various Fixes and Features

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -10,8 +10,9 @@ local function get_pitch_lift(y)
 	return l
 end
 
-local mouse_controls = minetest.settings:get_bool("glider_mouse_controls", true)
-local rocket_delay = tonumber(minetest.settings:get("glider_rocket_delay") or 10)
+local mouse_controls = minetest.settings:get_bool("glider.mouse_controls", true)
+local enable_rockets = minetest.settings:get_bool("glider.enable_rockets", true)
+local rocket_delay = tonumber(minetest.settings:get("glider.rocket_delay") or 10)
 
 local on_step = function(self, dtime, moveresult)
 	self.time_from_last_rocket = math.min(self.time_from_last_rocket+dtime,rocket_delay)
@@ -102,6 +103,9 @@ if rocket_delay >= 1 then
 	init_delay = rocket_delay
 end
 
+--
+-- Glider
+--
 minetest.register_entity("glider:hangglider", {
 	physical = true,
 	pointable = false,
@@ -153,36 +157,6 @@ minetest.register_tool("glider:glider", {
 	end,
 })
 
-minetest.register_craftitem("glider:rocket", {
-	description = "Rocket (Use while gliding to boost glider speed)",
-	inventory_image = "glider_rocket.png",
-	on_use = function(itemstack, user, pt)
-		local attach = user:get_attach()
-		if attach then
-			local luaent = attach:get_luaentity()
-			if luaent.name == "glider:hangglider" then
-				if luaent.time_from_last_rocket < rocket_delay then --anti rocket spam protection
-					return itemstack
-				end
-				luaent.speed = luaent.speed + luaent.time_from_last_rocket
-				luaent.time_from_last_rocket = 0
-				itemstack:take_item()
-				minetest.add_particlespawner({
-					amount = 1000,
-					time = 2,
-					minpos = {x = -0.125, y = -0.125, z = -0.125},
-					maxpos = {x = 0.125, y = 0.125, z = 0.125},
-					minexptime = 0.5,
-					maxexptime = 1.5,
-					attached = attach,
-					texture = "glider_rocket_particle.png",
-				})
-				return itemstack
-			end
-		end
-	end
-})
-
 minetest.register_craft({
 	output = "glider:glider",
 	recipe = {
@@ -192,11 +166,46 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "glider:rocket 33",
-	recipe = {
-		{"group:wood","tnt:gunpowder","group:wood"},
-		{"group:wood","tnt:gunpowder","group:wood"},
-		{"group:wood","tnt:gunpowder","group:wood"},
-	}
-})
+--
+--Rockets
+--
+if enable_rockets then
+	minetest.register_craftitem("glider:rocket", {
+		description = "Rocket (Use while gliding to boost glider speed)",
+		inventory_image = "glider_rocket.png",
+		on_use = function(itemstack, user, pt)
+			local attach = user:get_attach()
+			if attach then
+				local luaent = attach:get_luaentity()
+				if luaent.name == "glider:hangglider" then
+					if luaent.time_from_last_rocket < rocket_delay then --anti rocket spam protection
+						return itemstack
+					end
+					luaent.speed = luaent.speed + luaent.time_from_last_rocket
+					luaent.time_from_last_rocket = 0
+					itemstack:take_item()
+					minetest.add_particlespawner({
+						amount = 1000,
+						time = 2,
+						minpos = {x = -0.125, y = -0.125, z = -0.125},
+						maxpos = {x = 0.125, y = 0.125, z = 0.125},
+						minexptime = 0.5,
+						maxexptime = 1.5,
+						attached = attach,
+						texture = "glider_rocket_particle.png",
+					})
+					return itemstack
+				end
+			end
+		end
+	})
+
+	minetest.register_craft({
+		output = "glider:rocket 33",
+		recipe = {
+			{"group:wood","tnt:gunpowder","group:wood"},
+			{"group:wood","tnt:gunpowder","group:wood"},
+			{"group:wood","tnt:gunpowder","group:wood"},
+		}
+	})
+end

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,10 @@ local on_step = function(self, dtime, moveresult)
 	local actual_speed = math.sqrt(vel.x^2+vel.y^2+vel.z^2)
 	local rot = self.object:get_rotation()
 	local driver = minetest.get_player_by_name(self.driver)
+	if not driver then
+		self.object:remove()
+		return
+	end
 	local pos = self.object:get_pos()
 	
 	--Check Surroundings

--- a/init.lua
+++ b/init.lua
@@ -164,9 +164,9 @@ minetest.register_tool("glider:glider", {
 minetest.register_craft({
 	output = "glider:glider",
 	recipe = {
-		{"group:wool", "group:wool", "group:wool" },
-		{"group:stick","",           "group:stick"},
-		{"",           "group:stick",""           },
+		{"", "default:paper", "" },
+		{"default:paper","default:paper","default:paper"},
+		{"default:paper","group:stick","default:paper"},
 	}
 })
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,6 +1,9 @@
 #When enabled the player will control the glider via looking around.
 #When disabled the player will control the glider via the movement keys.
-glider_mouse_controls (Mouse Controls) bool true
+glider.mouse_controls (Mouse Controls) bool true
+
+#Enable rocket boost physics and craft recipe
+glider.enable_rockets (Enable rockets) bool true
 
 #Set the delay between rocket uses to avoid insane rocket-spam speeds
-glider_rocket_delay (Rocket Delay) int 10
+glider.rocket_delay (Rocket Delay) int 10

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,6 @@
 #When enabled the player will control the glider via looking around.
 #When disabled the player will control the glider via the movement keys.
 glider_mouse_controls (Mouse Controls) bool true
+
+#Set the delay between rocket uses to avoid insane rocket-spam speeds
+glider_rocket_delay (Rocket Delay) int 10


### PR DESCRIPTION
 - Fixes the nil-driver issue ( #7 ) (basically the same as #8 )
 - Changed settingtypes format from `mod_setting` to `mod.setting` as per modern standards
 - Allowed disabling the registration of rockets completely
 - Added a ratelimiter to rocket use to avoid Mach-spamming, configurable in settingtypes
 - Changed the craft recipe for the glider to avoid a recipe conflict with the (other) [hangglider](https://notabug.org/Piezo_/minetest-hangglider) mod